### PR TITLE
Fix python3 TypeError for get_version()

### DIFF
--- a/firefox_decrypt.py
+++ b/firefox_decrypt.py
@@ -72,7 +72,7 @@ def get_version():
     if p.returncode:
         return internal_version()
     else:
-        return stdout.strip()
+        return stdout.strip().decode("utf-8")
 
 
 __version_info__ = (0, 6)


### PR DESCRIPTION
Popen's stdout returns bytes, not a string, so decode to string.
Other code parts use .`decode("utf-8")` so inherits this behaviour.

Error was only for python3, not 2. Now works for both 2 & 3, tested with 2.7.13 & 3.5.3.