### PR TITLE
make --export-pass format compatible with browserpass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 #### Changelog
 
 ##### git
+- Add compatibility with browserpass via `--pass-compat=browserpass`
 
 ##### 0.7.0
 - Fix PK11 slot memory leak

--- a/README.md
+++ b/README.md
@@ -50,11 +50,12 @@ Since version **0.4** it is now also possible to export stored passwords to
 *pass* from http://passwordstore.org . To do so use:
 
 ```
-python firefox_decrypt.py --export-pass
+python firefox_decrypt.py --export-pass --pass-compat browserpass
 ```
 and **all** existing passwords will be exported after the pattern
 `web/<address>[:<port>]` unless multiple credentials exist for the same website
 in which case `/<login>` is appended.
+The username will be stored on a second line, prefixed with `login: ` for compatibility with the [browserpass](https://github.com/dannyvankooten/browserpass) extension if `--pass-compat browserpass` is specified. The default without `--pass-compat` is to store just the bare username.
 
 There is currently no way of selectively exporting passwords.
 Exporting overwrites existing passwords without warning. Make sure you have a

--- a/firefox_decrypt.py
+++ b/firefox_decrypt.py
@@ -539,7 +539,7 @@ def obtain_credentials(profile):
     return credentials
 
 
-def export_pass(to_export, prefix):
+def export_pass(to_export, prefix, username_prefix):
     """Export given passwords to password store
 
     Format of "to_export" should be:
@@ -558,7 +558,7 @@ def export_pass(to_export, prefix):
 
             LOG.debug("Exporting credentials for '%s'", passname)
 
-            data = u"{0}\n{1}\n".format(passw, user)
+            data = u"{0}\n{1}{2}\n".format(passw, username_prefix, user)
 
             LOG.debug("Inserting pass '%s' '%s'", passname, data)
 
@@ -760,6 +760,9 @@ def parse_sys_args():
                         help="Path to profile folder (default: {0})".format(profile_path))
     parser.add_argument("-e", "--export-pass", action="store_true",
                         help="Export URL, username and password to pass from passwordstore.org")
+    parser.add_argument("--pass-compat", action="store", choices={"default", "browserpass"},
+                        default="default",
+                        help="Export username as is (default), or prefixed with `login:` for compatibility with browserpass")
     parser.add_argument("-p", "--pass-prefix", action="store", default=u"web",
                         help="Prefix for export to pass from passwordstore.org (default: %(default)s)")
     parser.add_argument("-f", "--format", action="store", choices={"csv", "human"},
@@ -850,7 +853,8 @@ def main():
     )
 
     if args.export_pass:
-        export_pass(to_export, args.pass_prefix)
+        username_prefix = "login: " if args.pass_compat == "browserpass" else ""
+        export_pass(to_export, args.pass_prefix, username_prefix)
 
     # And shutdown NSS
     nss.unload_profile()


### PR DESCRIPTION
https://github.com/dannyvankooten/browserpass expects a multiline format with password first, and then a line with either login:, user: or username:.
Exporting passwords this way makes login form filling work if you have browserpass installed. Without it browserpass can't fill in the loginname, unless multiple accounts exist and the filename contains the account name.