### PR TITLE
Password import support

### DIFF
--- a/firefox_decrypt.py
+++ b/firefox_decrypt.py
@@ -354,7 +354,7 @@ class JsonCredentials(Credentials):
             if not changed:
                 continue
 
-            _, encryptedPassword = self._encoder(username, new_password)
+            _, encryptedPassword = encoder(username, new_password)
             entry['encryptedPassword'] = encryptedPassword
             changed_count += 1
 

--- a/firefox_decrypt.py
+++ b/firefox_decrypt.py
@@ -537,7 +537,8 @@ class NSSInteraction(object):
 
         return user, passw
 
-    def decrypt_passwords(self, export, output_format="human", csv_delimiter=";", csv_quotechar="|"):
+    def decrypt_passwords(self, export, output_format="human", csv_delimiter=";", csv_quotechar="|",
+                          pretty=False):
         """
         Decrypt requested profile using the provided password and print out all
         stored passwords.
@@ -604,7 +605,13 @@ class NSSInteraction(object):
                     sys.stdout.write(py2_encode(line, USR_ENCODING))
 
         if output_format == "json":
-            print(json.dumps(outputs))
+            if pretty:
+                output_str = json.dumps(outputs, indent=2)
+
+            else:
+                output_str = json.dumps(outputs)
+
+            print(output_str)
 
 
         credentials.done()
@@ -903,7 +910,7 @@ def parse_sys_args():
                         help="Prefix for export to pass from passwordstore.org (default: %(default)s)")
     parser.add_argument("-m", "--pass-cmd", action="store", default=u"pass",
                         help="Command/path to use when exporting to pass (default: %(default)s)")
-    parser.add_argument("-f", "--format", action="store", choices={"csv", "human", "json", "auto"},
+    parser.add_argument("-f", "--format", action="store", choices={"csv", "human", "json"},
                         default="human", help="Format for the output.")
     parser.add_argument("-d", "--delimiter", action="store", default=";",
                         help="The delimiter for csv output")
@@ -917,6 +924,7 @@ def parse_sys_args():
                         help="The profile to use (starts with 1). If only one profile, defaults to that.")
     parser.add_argument("-l", "--list", action="store_true",
                         help="List profiles and exit.")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print the output JSON")
     parser.add_argument("-v", "--verbose", action="count", default=0,
                         help="Verbosity level. Warning on -vv (highest level) user input will be printed on screen")
     parser.add_argument("--version", action="version", version=__version__,
@@ -932,12 +940,6 @@ def parse_sys_args():
         args.format = "csv"
         args.delimiter = "\t"
         args.quotechar = "'"
-
-    if args.format == "auto" and not args.update_from:
-        raise argparse.ArgumentError("--format", "`--format auto' can be used with `--update-from ...' only")
-
-    elif args.format == "human" and args.update_from:
-        raise argparse.ArgumentError("--format", "`--format human' cannot be used with `--update-from ...'")
 
     return args
 
@@ -996,6 +998,7 @@ def main():
         output_format=args.format,
         csv_delimiter=args.delimiter,
         csv_quotechar=args.quotechar,
+        pretty=args.pretty,
     )
 
     if args.export_pass:

--- a/firefox_decrypt.py
+++ b/firefox_decrypt.py
@@ -1202,7 +1202,7 @@ def parse_sys_args():
                         help="Prefix for export to pass from passwordstore.org (default: %(default)s)")
     parser.add_argument("-m", "--pass-cmd", action="store", default=u"pass",
                         help="Command/path to use when exporting to pass (default: %(default)s)")
-    parser.add_argument("-f", "--format", action="store", choices={"csv", "human", "json"},
+    parser.add_argument("-f", "--format", action="store", choices={"csv", "human", "json", "auto"},
                         default="human", help="Format for the output.")
     parser.add_argument("-d", "--delimiter", action="store", default=";",
                         help="The delimiter for csv output")
@@ -1219,7 +1219,6 @@ def parse_sys_args():
                         help="The profile to use (starts with 1). If only one profile, defaults to that.")
     parser.add_argument("-l", "--list", action="store_true",
                         help="List profiles and exit.")
-    parser.add_argument("--pretty", action="store_true", help="Pretty-print the output JSON")
     parser.add_argument("-u", "--update-from", action="store", metavar="INPUT_FILE",
                         help="Update passwords in database from CSV or JSON instead of exporting"
                              " (the file format is the same as the appropriate export format)")

--- a/firefox_decrypt.py
+++ b/firefox_decrypt.py
@@ -712,7 +712,7 @@ class NSSInteraction(object):
                     password_entries = list({ k: v.decode(USR_ENCODING) for k, v in entry } for entry in rdr)
 
                 else:
-                    password_entries = list(rdr)
+                    password_entries = list(entry for entry in rdr)
 
         elif input_format == 'json':
             with open_binary_input(source) as fd:

--- a/firefox_decrypt.py
+++ b/firefox_decrypt.py
@@ -602,8 +602,9 @@ class NSSInteraction(object):
                 )
                 for line in output:
                     sys.stdout.write(py2_encode(line, USR_ENCODING))
-            if output_format == "json":
-                print(json.dumps(outputs))
+
+        if output_format == "json":
+            print(json.dumps(outputs))
 
 
         credentials.done()
@@ -902,7 +903,7 @@ def parse_sys_args():
                         help="Prefix for export to pass from passwordstore.org (default: %(default)s)")
     parser.add_argument("-m", "--pass-cmd", action="store", default=u"pass",
                         help="Command/path to use when exporting to pass (default: %(default)s)")
-    parser.add_argument("-f", "--format", action="store", choices={"csv", "human", "json"},
+    parser.add_argument("-f", "--format", action="store", choices={"csv", "human", "json", "auto"},
                         default="human", help="Format for the output.")
     parser.add_argument("-d", "--delimiter", action="store", default=";",
                         help="The delimiter for csv output")
@@ -931,6 +932,12 @@ def parse_sys_args():
         args.format = "csv"
         args.delimiter = "\t"
         args.quotechar = "'"
+
+    if args.format == "auto" and not args.update_from:
+        raise argparse.ArgumentError("--format", "`--format auto' can be used with `--update-from ...' only")
+
+    elif args.format == "human" and args.update_from:
+        raise argparse.ArgumentError("--format", "`--format human' cannot be used with `--update-from ...'")
 
     return args
 

--- a/firefox_decrypt.py
+++ b/firefox_decrypt.py
@@ -1245,7 +1245,7 @@ def parse_sys_args():
     elif args.format == "human" and args.update_from:
         raise argparse.ArgumentError("--format", "`--format human' cannot be used with `--update-from ...'")
 
-    # --no-input impliies --no-interactive
+    # --no-input implies --no-interactive
     if args.no_input:
         args.interactive = False
 

--- a/firefox_decrypt.py
+++ b/firefox_decrypt.py
@@ -242,7 +242,7 @@ class SqliteCredentialsWriter(CredentialsFile):
     def __init__(self, profile):
         db = os.path.join(profile, "signons.sqlite")
 
-        super(SqliteCredentials, self).__init__(db)
+        super(SqliteCredentialsWriter, self).__init__(db)
 
         self.conn = sqlite3.connect(db)
 
@@ -292,7 +292,7 @@ class JsonCredentialsWriter(CredentialsFile):
     def __init__(self, profile):
         db = os.path.join(profile, "logins.json")
 
-        super(JsonCredentials, self).__init__(db)
+        super(JsonCredentialsWriter, self).__init__(db)
 
     def __enter__(self):
         self.pass_list = {}

--- a/firefox_decrypt.py
+++ b/firefox_decrypt.py
@@ -1082,7 +1082,7 @@ def ask_password(profile, getpass_mode):
     if sys.stdin.isatty() and getpass_mode == GETPASS_INTERACTIVE:
         passwd = getpass(passmsg)
 
-    elif getpass_mode == GETPASS_STDIN:
+    elif getpass_mode == GETPASS_STDIN or getpass_mode == GETPASS_INTERACTIVE:
         # Ability to read the password from stdin (echo "pass" | ./firefox_...)
         if sys.stdin in select.select([sys.stdin], [], [], 0)[0]:
             passwd = sys.stdin.readline().rstrip("\n")

--- a/firefox_decrypt.py
+++ b/firefox_decrypt.py
@@ -1154,6 +1154,7 @@ def parse_sys_args():
     parser.add_argument("-u", "--update-from", action="store", metavar="INPUT_FILE",
                         help="Update passwords in database from CSV or JSON instead of exporting"
                              " (the file format is the same as the appropriate export format)")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print the output JSON")
     parser.add_argument("-v", "--verbose", action="count", default=0,
                         help="Verbosity level. Warning on -vv (highest level) user input will be printed on screen")
     parser.add_argument("--version", action="version", version=__version__,
@@ -1238,7 +1239,7 @@ def main():
             output_format=args.format,
             csv_delimiter=args.delimiter,
             csv_quotechar=args.quotechar,
-            pretty=args.pretty,
+            pretty=args.pretty
         )
 
         if args.export_pass:

--- a/firefox_decrypt.py
+++ b/firefox_decrypt.py
@@ -173,7 +173,7 @@ class Exit(Exception):
         return "Premature program exit with exit code {0}".format(self.exitcode)
 
 
-class CredentialsFile(object):
+class Credentials(object):
     """Base credentials backend manager
     """
     def __init__(self, db):
@@ -192,7 +192,7 @@ class CredentialsFile(object):
         pass
 
 
-class SqliteCredentials(CredentialsFile):
+class SqliteCredentials(Credentials):
     """SQLite credentials backend manager
     """
     def __init__(self, profile):
@@ -288,7 +288,7 @@ class SqliteCredentials(CredentialsFile):
         super(SqliteCredentials, self).done()
 
 
-class JsonCredentials(CredentialsFile):
+class JsonCredentials(Credentials):
     """JSON credentials backend manager
     """
     def __init__(self, profile):

--- a/tests/import.t
+++ b/tests/import.t
@@ -68,11 +68,8 @@ class TestImport(unittest.TestCase):
             with open(dest_json, 'wt') as fd:
                 json.dump(import_context.changed_entries, fd)
 
-            import sys
-            print(json.dumps(import_context.changed_entries), file=sys.stderr)
             cmd = command_begin + ["--format", "json", "--update", dest_json]
-            lib.run(cmd, stdin=stdin)
-            #lib.run(cmd, stdin=self.pwd, stderr=subprocess.DEVNULL)
+            lib.run(cmd, stdin=stdin, stderr=subprocess.DEVNULL)
 
             cmd = command_begin + ["--format", "json"]
             new_output = lib.run(cmd, stdin=stdin, stderr=subprocess.DEVNULL)

--- a/tests/import.t
+++ b/tests/import.t
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+
+import unittest
+import os
+import shutil
+import contextlib
+import copy
+import json
+import tempfile
+import subprocess
+from simpletap.fdecrypt import lib
+
+
+class TestImport(unittest.TestCase):
+    def setUp(self):
+        self.test = lib.get_test_data()
+        self.pwd = lib.get_password()
+
+    @contextlib.contextmanager
+    def prepare_temp_profile(self, dirname):
+        sourcedir = os.path.join(self.test, dirname)
+        targetdir = tempfile.mkdtemp()
+        os.rmdir(targetdir)
+        shutil.copytree(sourcedir, targetdir)
+
+        try:
+            yield targetdir
+
+        finally:
+            shutil.rmtree(targetdir, ignore_errors=True)
+
+    class ImportContext:
+        def __init__(self, original_content):
+            self.original_content = original_content
+            self.changed_content = copy.deepcopy(original_content)
+            self.changed_entries = []
+
+        def change_entries(self, *patterns):
+            for old_entry, new_entry in zip(self.original_content, self.changed_content):
+                for pattern in patterns:
+                    if pattern in old_entry['user']:
+                        yield new_entry
+                        if old_entry != new_entry:
+                            self.changed_entries.append(new_entry)
+
+                        break
+
+    @contextlib.contextmanager
+    def validate_profile_change(self, dirname, password=None):
+        with self.prepare_temp_profile(dirname) as trgdir:
+            command_begin = lib.get_script() + [trgdir]
+
+            if password is None:
+                stdin = None
+                command_begin += ['-n']
+
+            else:
+                stdin = password
+
+            cmd = command_begin + ["--format", "json"]
+            output = lib.run(cmd, stdin=stdin, stderr=subprocess.DEVNULL)
+            orig_data = list(sorted(json.loads(output), key=lambda entry: entry['user']))
+
+            import_context = self.ImportContext(orig_data)
+            yield import_context
+
+            dest_json = os.path.join(trgdir, "import.json")
+            with open(dest_json, 'wt') as fd:
+                json.dump(import_context.changed_entries, fd)
+
+            import sys
+            print(json.dumps(import_context.changed_entries), file=sys.stderr)
+            cmd = command_begin + ["--format", "json", "--update", dest_json]
+            lib.run(cmd, stdin=stdin)
+            #lib.run(cmd, stdin=self.pwd, stderr=subprocess.DEVNULL)
+
+            cmd = command_begin + ["--format", "json"]
+            new_output = lib.run(cmd, stdin=stdin, stderr=subprocess.DEVNULL)
+            new_data = list(sorted(json.loads(output), key=lambda entry: entry['user']))
+
+            self.assertEqual(new_data, orig_data)
+
+    def validate_reversed_password(self, dirname, patterns, password=None):
+        with self.validate_profile_change(dirname, password) as context:
+            for entry in context.change_entries(*patterns):
+                entry['password'] = ''.join(reversed(entry['password']))
+
+    def test_firefox_20_default(self):
+        self.validate_reversed_password("test_profile_firefox_20",
+                [ "doesntexist" ], password=self.pwd)
+        self.validate_reversed_password("test_profile_firefox_20",
+                [ "onemore" ], password=self.pwd)
+        self.validate_reversed_password("test_profile_firefox_20",
+                [ "cömplex" ], password=self.pwd)
+        self.validate_reversed_password("test_profile_firefox_20",
+                [ "jãmïe" ] , password=self.pwd)
+        self.validate_reversed_password("test_profile_firefox_20",
+                [ "doesntexist", "onemore", "cömplex", "jãmïe" ], password=self.pwd)
+
+    def test_firefox_46_default(self):
+        self.validate_reversed_password("test_profile_firefox_46",
+                [ "doesntexist" ], password=self.pwd)
+        self.validate_reversed_password("test_profile_firefox_46",
+                [ "onemore" ], password=self.pwd)
+        self.validate_reversed_password("test_profile_firefox_46",
+                [ "cömplex" ], password=self.pwd)
+        self.validate_reversed_password("test_profile_firefox_46",
+                [ "jãmïe" ] , password=self.pwd)
+        self.validate_reversed_password("test_profile_firefox_46",
+                [ "doesntexist", "onemore", "cömplex", "jãmïe" ], password=self.pwd)
+
+    def test_firefox_59_default(self):
+        self.validate_reversed_password("test_profile_firefox_59",
+                [ "doesntexist" ], password=self.pwd)
+        self.validate_reversed_password("test_profile_firefox_59",
+                [ "onemore" ], password=self.pwd)
+        self.validate_reversed_password("test_profile_firefox_59",
+                [ "cömplex" ], password=self.pwd)
+        self.validate_reversed_password("test_profile_firefox_59",
+                [ "jãmïe" ] , password=self.pwd)
+        self.validate_reversed_password("test_profile_firefox_59",
+                [ "doesntexist", "onemore", "cömplex", "jãmïe" ], password=self.pwd)
+
+    def test_firefox_nopassword_default(self):
+        self.validate_reversed_password("test_profile_firefox_nopassword",
+                [ "doesntexist" ])
+        self.validate_reversed_password("test_profile_firefox_nopassword",
+                [ "onemore" ])
+        self.validate_reversed_password("test_profile_firefox_nopassword",
+                [ "cömplex" ])
+        self.validate_reversed_password("test_profile_firefox_nopassword",
+                [ "jãmïe" ] )
+        self.validate_reversed_password("test_profile_firefox_nopassword",
+                [ "doesntexist", "onemore", "cömplex", "jãmïe" ])
+
+
+if __name__ == "__main__":
+    from simpletap import TAPTestRunner
+    unittest.main(testRunner=TAPTestRunner())
+
+# vim: ai sts=4 et sw=4

--- a/tests/json.t
+++ b/tests/json.t
@@ -23,7 +23,13 @@ class TestJSON(unittest.TestCase):
             self.assertDictEqual(entry, expected_data)
             break
 
-    def validate_indentation(self, out, indent_map):
+    def validate_indentation(self, out):
+        data = json.loads(out)
+        indent_map = {
+            '': 2,
+            '  ': 2 * len(data),
+            '    ': sum(len(element) for element in data)
+            }
         indent_counts = {}
         for line in out.strip().splitlines():
             m = re.match(r'^(\s*)', line)
@@ -47,7 +53,7 @@ class TestJSON(unittest.TestCase):
         self.validate_one("onemore_json_pretty", "onemore", out)
         self.validate_one("complex_json_pretty", "cömplex", out)
         self.validate_one("jamie_json_pretty", "jãmïe", out)
-        self.validate_indentation(out, { '': 2, '  ': 8, '    ': 12 })
+        self.validate_indentation(out)
 
     def test_firefox_20_default(self):
         test = os.path.join(self.test, "test_profile_firefox_20")

--- a/tests/json.t
+++ b/tests/json.t
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+
+import os
+import json
+import unittest
+import subprocess
+import re
+from simpletap.fdecrypt import lib
+
+
+class TestJSON(unittest.TestCase):
+    def setUp(self):
+        self.test = lib.get_test_data()
+        self.pwd = lib.get_password()
+
+    def validate_one(self, userkey, grepkey, output):
+        data = json.loads(output)
+        expected_data = json.loads(lib.get_user_data(userkey))
+        for entry in data:
+            if grepkey not in entry['user']:
+                continue
+
+            self.assertDictEqual(entry, expected_data)
+            break
+
+    def validate_indentation(self, out, indent_map):
+        indent_counts = {}
+        for line in out.strip().splitlines():
+            m = re.match(r'^(\s*)', line)
+            if m:
+                indent = m.group(1)
+                try:
+                    indent_counts[indent] += 1
+                except KeyError:
+                    indent_counts[indent] = 1
+
+        self.assertDictEqual(indent_counts, indent_map)
+
+    def validate_default(self, out):
+        self.validate_one("doesntexist_json_pretty", "doesntexist", out)
+        self.validate_one("onemore_json_pretty", "onemore", out)
+        self.validate_one("complex_json_pretty", "cömplex", out)
+        self.validate_one("jamie_json_pretty", "jãmïe", out)
+
+    def validate_pretty(self, out):
+        self.validate_one("doesntexist_json_pretty", "doesntexist", out)
+        self.validate_one("onemore_json_pretty", "onemore", out)
+        self.validate_one("complex_json_pretty", "cömplex", out)
+        self.validate_one("jamie_json_pretty", "jãmïe", out)
+        self.validate_indentation(out, { '': 2, '  ': 8, '    ': 12 })
+
+    def test_firefox_20_default(self):
+        test = os.path.join(self.test, "test_profile_firefox_20")
+
+        cmd = lib.get_script() + [test, "--format", "json"]
+        output = lib.run(cmd, stdin=self.pwd, stderr=subprocess.DEVNULL)
+        self.validate_default(output)
+
+    def test_firefox_20_pretty(self):
+        test = os.path.join(self.test, "test_profile_firefox_20")
+
+        cmd = lib.get_script() + [test, "--format", "json", "--pretty"]
+        output = lib.run(cmd, stdin=self.pwd, stderr=subprocess.DEVNULL)
+        self.validate_pretty(output)
+
+    def test_firefox_46_default(self):
+        test = os.path.join(self.test, "test_profile_firefox_46")
+
+        cmd = lib.get_script() + [test, "--format", "json"]
+        output = lib.run(cmd, stdin=self.pwd, stderr=subprocess.DEVNULL)
+        self.validate_default(output)
+
+    def test_firefox_46_pretty(self):
+        test = os.path.join(self.test, "test_profile_firefox_46")
+
+        cmd = lib.get_script() + [test, "--format", "json", "--pretty"]
+        output = lib.run(cmd, stdin=self.pwd, stderr=subprocess.DEVNULL)
+        self.validate_pretty(output)
+
+    def test_firefox_59_default(self):
+        test = os.path.join(self.test, "test_profile_firefox_59")
+
+        cmd = lib.get_script() + [test, "--format", "json"]
+        output = lib.run(cmd, stdin=self.pwd, stderr=subprocess.DEVNULL)
+        self.validate_default(output)
+
+    def test_firefox_59_pretty(self):
+        test = os.path.join(self.test, "test_profile_firefox_59")
+
+        cmd = lib.get_script() + [test, "--format", "json", "--pretty"]
+        output = lib.run(cmd, stdin=self.pwd, stderr=subprocess.DEVNULL)
+        self.validate_pretty(output)
+
+    def test_firefox_nopassword_default(self):
+        test = os.path.join(self.test, "test_profile_firefox_nopassword")
+
+        cmd = lib.get_script() + [test, "-n", "--format", "json"]
+        output = lib.run(cmd, stderr=subprocess.DEVNULL)
+        self.validate_default(output)
+
+    def test_firefox_nopassword_pretty(self):
+        test = os.path.join(self.test, "test_profile_firefox_nopassword")
+
+        cmd = lib.get_script() + [test, "-n", "--format", "json", "--pretty"]
+        output = lib.run(cmd, stderr=subprocess.DEVNULL)
+        self.validate_pretty(output)
+
+
+if __name__ == "__main__":
+    from simpletap import TAPTestRunner
+    unittest.main(testRunner=TAPTestRunner())
+
+# vim: ai sts=4 et sw=4

--- a/tests/test_data/users/complex_json_pretty.user
+++ b/tests/test_data/users/complex_json_pretty.user
@@ -1,0 +1,5 @@
+  {
+    "url": "https://github.com",
+    "user": "c\u00f6mplex",
+    "password": "\u0441\u042e\u041b\u041e\u0430\u0436\u0441$4vz*V\u00e7\u00e0hxpfCbmwo"
+  }

--- a/tests/test_data/users/doesntexist_json_pretty.user
+++ b/tests/test_data/users/doesntexist_json_pretty.user
@@ -1,0 +1,5 @@
+  {
+    "url": "https://github.com",
+    "user": "doesntexist",
+    "password": "xrbSDzYf94gfk"
+  }

--- a/tests/test_data/users/jamie_json_pretty.user
+++ b/tests/test_data/users/jamie_json_pretty.user
@@ -1,0 +1,5 @@
+  {
+    "url": "https://github.com",
+    "user": "j\u00e3m\u00efe",
+    "password": "Apassword\twithtabs,;colonandsemi'\"andquotes"
+  }

--- a/tests/test_data/users/onemore_json_pretty.user
+++ b/tests/test_data/users/onemore_json_pretty.user
@@ -1,0 +1,5 @@
+  {
+    "url": "https://github.com",
+    "user": "onemore",
+    "password": "}]\u00a2\u00f6\u00f0\u00e6[{"
+  }


### PR DESCRIPTION
* Updates both JSON- and SQLite-based login databases
* Three master password input modes (interactive, stdin and disabled) instead of two, the latter is used to prevent conflicts with feeding updated passwords from stdin
* Made `SECItem` class use `POINTER(c_char)` instead of `c_char_p`
* Unit tests

**NOTE**
* Includes patches from #55, I will rebase this one to master when that PR is merged
* Tested on Linux **only**

Fixes #47 