### PR TITLE
👷 use latest major version for actions/checkout (main instead of abandoned master branch/head)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       # Needed to force UTF-8 and have consistent behavior in Windows
       PYTHONUTF8: 1
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@main
       - name: Set up Python
         uses: actions/setup-python@master
         with:


### PR DESCRIPTION
Use latest major version of [actions/checkout](https://github.com/actions/checkout) for GitHub Actions: main instead of master!