### PR TITLE
Added elif clause on lAdd Snap path handling for Ubuntu in the Firefox configurationine 991 to account for Snap paths on Ubuntu sys…

### DIFF
--- a/firefox_decrypt.py
+++ b/firefox_decrypt.py
@@ -337,7 +337,7 @@ def load_libnss():
             "/Applications/SeaMonkey.app/Contents/MacOS",
             "/Applications/Waterfox.app/Contents/MacOS",
         ]
-
+    
     else:
         nssname = "libnss3.so"
         if SYS64:
@@ -987,6 +987,13 @@ def parse_sys_args() -> argparse.Namespace:
         profile_path = os.path.join(os.environ["APPDATA"], "Mozilla", "Firefox")
     elif os.uname()[0] == "Darwin":
         profile_path = "~/Library/Application Support/Firefox"
+    
+    elif "buntu" in platform.version():
+        try:
+            profile_path = "~/snap/firefox/common/.mozilla/firefox" # accounts for snaps
+        except:
+            profile_path = "~/.mozilla/firefox"
+    
     else:
         profile_path = "~/.mozilla/firefox"
 


### PR DESCRIPTION
Added elif clause on line 991 to account for Snap paths on Ubuntu systems, ensuring compatibility with Snap-based Firefox installations. No other changes made outside of this clause.