### PR TITLE
Add decrypt-all feature

### DIFF
--- a/firefox_decrypt.py
+++ b/firefox_decrypt.py
@@ -1114,7 +1114,6 @@ def parse_sys_args() -> argparse.Namespace:
         default=False,
         help="Tries to decrypt all profiles.",
         )
-    # make a loop in main to do the whole process with all profiles. :')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
This PR adds `--decrypt-all` option to let users decrypt all profile sections in order. Also, it modifies error handling to make it work with the new feature.

```
python3 firefox_decrypt.py --decrypt-all
2025-10-05 07:49:24,314 - ERROR - Couldn't initialize NSS, maybe '/home/kali/.mozilla/firefox/vqkc63jt.default' is not a valid profile?
Exception 12 happened, moving to next section!

Website:   https://practicetestautomation.com
Username: 'student'
Password: 'Password123'
```

**Note:** This PR might break the original code style and further testing might be required. I only have tested it on Windows 10 x64 and Kali Linux x86_64.